### PR TITLE
Fix Travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ python:
 env:
   - REQFILE=requirements.txt
   - REQFILE=hamcrest.txt
-install: pip install -r $REQFILE --use-mirrors
+install: pip install -r $REQFILE
 # command to run tests, e.g. python setup.py test
 script:  nosetests
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,9 @@ python:
 env:
   - REQFILE=requirements.txt
   - REQFILE=hamcrest.txt
-install: pip install -r $REQFILE
+install:
+  - pip install setuptools --upgrade # fix for html5lib
+  - pip install -r $REQFILE
 # command to run tests, e.g. python setup.py test
 script:  nosetests
 matrix:


### PR DESCRIPTION
--use-mirrors isn't supported, so remove it.

Also, ensure we have latest setuptools, so html5lib install doesn't fail.

(html5lib has this problem fixed, just not released on PyPI yet.)